### PR TITLE
Improve holoinstall Script

### DIFF
--- a/src/holoinstall
+++ b/src/holoinstall
@@ -116,7 +116,11 @@ partitioning(){
 			echo "\nHoloISO will be installed alongside existing OS/Partition.\nPlease make sure there are more than 24 GB on the >>END<< of free(unallocate) space available\n"
 			parted $DEVICE print free
 			echo "HoloISO will be installed on the following free(unallocate) space.\n"
-			parted $DEVICE print free | tail -n2
+			parted $DEVICE print free | tail -n2 | grep "Free Space"
+			if [ $? != 0 ]; then
+				echo "Error! No Free Space found on the end of the disk.\nNothing has been written.\nYou canceled the non-destructive install, please try again"
+				exit 1
+			fi
 			echo -n "\nDoes this look reasonable(y/n): "
 			read ANS
 			case $ANS in

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -244,8 +244,10 @@ base_os_install() {
 	sleep 2
 	arch-chroot ${HOLO_INSTALL_DIR} depmod -a $(ls /lib/modules)
 	arch-chroot ${HOLO_INSTALL_DIR} mkinitcpio -P
-	mount -t ext4 ${home_partition} ${HOLO_INSTALL_DIR}/home
-	check_mount $? home
+	if [ $home ]; then
+		mount -t ext4 ${home_partition} ${HOLO_INSTALL_DIR}/home
+		check_mount $? home
+	fi
 	
 	echo "\nBase system installation done, generating fstab..."
 	genfstab -U -p /mnt >> /mnt/etc/fstab

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -74,6 +74,12 @@ partitioning(){
 		echo "$DEVICE not found! Installation Aborted!"
 		exit 1
 	fi
+	lsblk $DEVICE | head -n2 | tail -n1 | grep disk > /dev/null 2>&1
+	if [ $? != 0 ]; then
+		echo "$DEVICE is not disk type! Installation Aborted!"
+		ehho "\nNote: If you wish to preform partition install.\n Please specify the disk drive node first then select \"2\" for partition install."
+		exit 1
+	fi
 	
 	echo "1) Erase your drive\n2) Install alongside existing OS/Partition\nType 1 or 2: "
 	read "?Your choice is: " install

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -77,7 +77,7 @@ partitioning(){
 	lsblk $DEVICE | head -n2 | tail -n1 | grep disk > /dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "$DEVICE is not disk type! Installation Aborted!"
-		echo "\nNote: If you wish to preform partition install.\n Please specify the disk drive node first then select \"2\" for partition install."
+		echo "\nNote: If you wish to preform partition install.\nPlease specify the disk drive node first then select \"2\" for partition install."
 		exit 1
 	fi
 	

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -77,7 +77,7 @@ partitioning(){
 	lsblk $DEVICE | head -n2 | tail -n1 | grep disk > /dev/null 2>&1
 	if [ $? != 0 ]; then
 		echo "$DEVICE is not disk type! Installation Aborted!"
-		ehho "\nNote: If you wish to preform partition install.\n Please specify the disk drive node first then select \"2\" for partition install."
+		echo "\nNote: If you wish to preform partition install.\n Please specify the disk drive node first then select \"2\" for partition install."
 		exit 1
 	fi
 	

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -107,8 +107,10 @@ partitioning(){
 			esac
 			;;
 		2)
-			echo "\nHoloISO will be installed alongside existing OS/Partition.\nPlease make sure there are more than 24 GB of free space available\n"
-			lsblk -o NAME,MAJ:MIN,RM,SIZE,RO,TYPE,VENDOR,MODEL,SERIAL,MOUNTPOINT $DEVICE
+			echo "\nHoloISO will be installed alongside existing OS/Partition.\nPlease make sure there are more than 24 GB on the >>END<< of free(unallocate) space available\n"
+			parted $DEVICE print free
+			echo "HoloISO will be installed on the following free(unallocate) space.\n"
+			parted $DEVICE print free | tail -n2
 			echo -n "\nDoes this look reasonable(y/n): "
 			read ANS
 			case $ANS in


### PR DESCRIPTION
Address the following issue:
- Fix skip mounting home partition when home partition is not created (https://github.com/theVakhovskeIsTaken/holoiso/issues/356)
- Error outs when user input the partition node during drive selection screen
![VirtualBox_Arch Linux_13_07_2022_15_45_05](https://user-images.githubusercontent.com/10562889/178679620-9061938b-0b3a-4f17-81de-05d3081ae8fe.png)

- Make a better partition confirmation screen. This screen tells holoiso will install on the following free(unallocate) space at the end of the disk.
![VirtualBox_Arch Linux_13_07_2022_15_46_18](https://user-images.githubusercontent.com/10562889/178679636-8f1caea0-52e2-4073-a9af-445c5093479e.png)

