### PR TITLE
Check Username Before Create User

### DIFF
--- a/src/holoinstall
+++ b/src/holoinstall
@@ -303,7 +303,7 @@ base_os_install() {
 		read "?Enter username for this installation: " HOLOUSER
 		if [ $HOLOUSER = "root" ]; then
 			echo "User \"root\" already exists!"
-		elif [[ ! $HOLOUSER =~ $NAME_REGEX ]]
+		elif [[ ! $HOLOUSER =~ $NAME_REGEX ]]; then
 			echo "Invalid username \"$HOLOUSER\""
 		else
 			break

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -303,8 +303,14 @@ base_os_install() {
 		read "?Enter username for this installation: " HOLOUSER
 		if [ $HOLOUSER = "root" ]; then
 			echo "User \"root\" already exists!"
+		elif [ ${#HOLOUSER} -gt 32 ]; then
+			echo "Username must not exceed 32 characters long"
 		elif [[ ! $HOLOUSER =~ $NAME_REGEX ]]; then
 			echo "Invalid username \"$HOLOUSER\""
+			echo "Username need to follow these rules:"
+			echo
+			echo "- Must start with a lower-case letter."
+			echo "- May only contain lowercase letters, digits, hyphens, and underscores."
 		else
 			break
 		fi

--- a/src/holoinstall
+++ b/src/holoinstall
@@ -298,10 +298,13 @@ base_os_install() {
 		echo "Error: Password does not match."
 	done
 	# Create user
+	NAME_REGEX="^[a-z][-a-z0-9_]*\$"
 	while true; do
 		read "?Enter username for this installation: " HOLOUSER
 		if [ $HOLOUSER = "root" ]; then
 			echo "User \"root\" already exists!"
+		elif [[ ! $HOLOUSER =~ $NAME_REGEX ]]
+			echo "Invalid username \"$HOLOUSER\""
 		else
 			break
 		fi


### PR DESCRIPTION
This pull request address the following issue:
- If username include invalid character, then it'll failed to create user, result no gamescope session/ stuck at sddm with no user upon reboot (e.g. uppercase or first word start with a non-lower-case letter)